### PR TITLE
Remove Shadow DOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   "license": "MIT",
   "repository": "https://github.com/nyxtom/anderson-dark-ui",
   "engines": {
-    "atom": ">0.40.0"
+    "atom": ">=1.13.0"
   }
 }

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -1,7 +1,7 @@
 @import "ui-variables";
 @import "ui-mixins";
 
-atom-text-editor[mini], atom-text-editor[mini]::shadow {
+atom-text-editor[mini], atom-text-editor[mini].editor {
   color: @text-color-highlight;
   background-color: @input-background-color;
   border: 1px solid @input-border-color;
@@ -13,13 +13,13 @@ atom-text-editor[mini], atom-text-editor[mini]::shadow {
   .selection .region { background-color: lighten(@input-background-color, 10%); }
 }
 
-atom-text-editor[mini].is-focused, atom-text-editor[mini].is-focused::shadow {
+atom-text-editor[mini].is-focused, atom-text-editor[mini].is-focused.editor {
   background-color: lighten(@input-background-color, 5%);
   .selection .region { background-color: desaturate(@background-color-info, 50%); }
 }
 
 // FIXME: these should go in syntax themes?
-atom-text-editor, atom-text-editor::shadow {
+atom-text-editor, atom-text-editor.editor {
   .gutter.drop-shadow {
     -webkit-box-shadow: -2px 0 10px 2px #222;
   }


### PR DESCRIPTION
I love this theme, but Atom's `deprecation-cop` keeps reporting this:

> Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary. This means you should stop using :host and ::shadow pseudo-selectors, and prepend all your syntax selectors with syntax--.

See [Removing Shadow DOM](https://flight-manual.atom.io/shadow-dom/sections/removing-shadow-dom-styles/) for details.

Anyway, this PR contains all the necessary changes to fix that. Old versions of Atom will continue using the old version, so all's good.